### PR TITLE
Burrow BaseURL change needed for upgraded burrow

### DIFF
--- a/src/main/scala/com/github/splee/burrower/OffsetMonitor.scala
+++ b/src/main/scala/com/github/splee/burrower/OffsetMonitor.scala
@@ -62,7 +62,7 @@ class OffsetMonitor (
   writer: Writer
 ) extends Runnable with LazyLogging {
 
-  val burrowBaseUrl = f"http://$burrowHost:$burrowPort/v2/kafka"
+  val burrowBaseUrl = f"http://$burrowHost:$burrowPort/v3/kafka"
 
   def run(): Unit = {
     while (true) {


### PR DESCRIPTION
Burrow upgrade has changed their base url to "http://$burrowHost:$burrowPort/v3/kafka". Burrower needs to be re-compiled with this new config. Please verify and merge